### PR TITLE
version for distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /target
 /build
+/dist
 /node_modules
 /coverage
 /instrument

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "spec": "gulp spec",
     "instrument": "istanbul instrument --output instrument lib/",
     "cover": "npm run instrument && gulp cover",
-    "test": "gulp test"
+    "test": "gulp test",
+    "prepublish": "mkdir -p dist && browserify $npm_package_main --standalone Cookie --outfile dist/cookie.js"
   },
   "mdp": {
     "title": "Cookie",


### PR DESCRIPTION
Would you consider including a pre-publish task to generate a browserify-standalone build of this?

We use browserify for our library as well, but we have need to use this in raw script-global form as well. Building the standalone version would be greatly appreciated.
